### PR TITLE
Tomo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ var/
 .installed.cfg
 *.egg
 
+# python envirnoment
+.venv
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/setup.py
+++ b/setup.py
@@ -1,34 +1,36 @@
 from setuptools import setup
 
-with open('requirements.txt') as f:
-    requirements = f.read().splitlines()
+with open("requirements.txt") as f:
+    requirements_unfiltered = f.read().splitlines()
+    # remove TA-Lib from requirements because it belongs to extras_required
+    requirements = [req for req in requirements_unfiltered if "TA-Lib" not in req]
 
 setup(
-    name='pinkfish',
-    version='2.0.0',
-    description='A backtester and spreadsheet library for security analysis.',
-    author='Farrell Aultman',
-    author_email='fja0568@gmail.com',
-    url='https://github.com/fja05680/pinkfish',
-    packages=['pinkfish'],
+    name="pinkfish",
+    version="2.0.0",
+    description="A backtester and spreadsheet library for security analysis.",
+    author="Farrell Aultman",
+    author_email="fja0568@gmail.com",
+    url="https://github.com/fja05680/pinkfish",
+    packages=["pinkfish"],
     include_package_data=True,
-    license='MIT',
+    license="MIT",
     install_requires=requirements,
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'License :: OSI Approved :: MIT License',
-        'Natural Language :: English',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Operating System :: OS Independent',
-        'Intended Audience :: Science/Research',
-        'Topic :: Office/Business :: Financial',
-        'Topic :: Scientific/Engineering :: Information Analysis',
-        'Topic :: System :: Distributed Computing',
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Operating System :: OS Independent",
+        "Intended Audience :: Science/Research",
+        "Topic :: Office/Business :: Financial",
+        "Topic :: Scientific/Engineering :: Information Analysis",
+        "Topic :: System :: Distributed Computing",
     ],
     extras_require={
-        'talib':  ["talib"],
+        "talib": ["TA-Lib"],
     },
-    data_files=[('', ['requirements.txt'])],
+    data_files=[("", ["requirements.txt"])],
     python_requires=">=3.7",
 )


### PR DESCRIPTION
Pinkfish still required TA-Lib when `pip install pinkfish` . It's supposed to be only in extras