### PR TITLE
Add FXMacroData FX timeseries fetcher

### DIFF
--- a/pinkfish/__init__.py
+++ b/pinkfish/__init__.py
@@ -1,5 +1,6 @@
 from .fetch import (
     fetch_timeseries,
+    fetch_fxmacrodata_timeseries,
     select_tradeperiod,
     finalize_timeseries,
     remove_cache_symbols,

--- a/pinkfish/fetch.py
+++ b/pinkfish/fetch.py
@@ -8,6 +8,7 @@ import sys
 import warnings
 
 import pandas as pd
+import requests
 import yfinance as yf
 
 from pinkfish.pfstatistics import (
@@ -21,6 +22,8 @@ import pinkfish.utility as utility
 
 ########################################################################
 # TIMESERIES (fetch, select, finalize)
+
+FXMACRODATA_API_ROOT = 'https://fxmacrodata.com/api/v1'
 
 def _get_cache_dir(dir_name):
     """
@@ -70,6 +73,68 @@ def _adj_column_names(ts):
     """
     ts.columns = [col.lower().replace(' ','_') for col in ts.columns]
     ts.index.names = ['date']
+    return ts
+
+
+def _split_fx_pair(pair):
+    pair = pair.upper().replace('/', '').replace('-', '').replace('_', '')
+    if len(pair) != 6:
+        raise ValueError("FX pair must be formatted like 'EURUSD' or 'EUR/USD'")
+    return pair[:3], pair[3:]
+
+
+def fetch_fxmacrodata_timeseries(pair, start, end, api_key=None,
+                                 api_root=FXMACRODATA_API_ROOT,
+                                 dir_name='fxmacrodata-cache',
+                                 use_cache=True):
+    """
+    Read daily FX reference rates from FXMacroData.
+
+    FXMacroData returns one official reference value per date. Pinkfish expects
+    OHLCV-style bars, so the reference value is copied into open, high, low,
+    close, and adj_close with zero volume.
+    """
+    base, quote = _split_fx_pair(pair)
+    symbol = base + quote
+    timeseries_cache = _get_cache_dir(dir_name) / f'{symbol}.csv'
+
+    if not (timeseries_cache.is_file() and use_cache):
+        params = {
+            'start_date': start,
+            'end_date': end,
+            'limit': 5000,
+        }
+        if api_key:
+            params['api_key'] = api_key
+
+        url = f"{api_root.rstrip('/')}/forex/{base}/{quote}"
+        response = requests.get(url, params=params, timeout=30)
+        response.raise_for_status()
+        rows = response.json().get('data', [])
+
+        records = []
+        for row in rows:
+            value = float(row['val'])
+            records.append({
+                'Date': row['date'],
+                'Open': value,
+                'High': value,
+                'Low': value,
+                'Close': value,
+                'Adj Close': value,
+                'Volume': 0.0,
+            })
+
+        ts = pd.DataFrame.from_records(records)
+        if ts.empty:
+            print(f'No FXMacroData data for {base}/{quote}')
+            return None
+        ts = ts.sort_values('Date')
+        ts.to_csv(timeseries_cache, index=False, encoding='utf-8')
+
+    ts = pd.read_csv(timeseries_cache, index_col='Date', parse_dates=True)
+    ts = _adj_column_names(ts)
+    ts = ts[~ts.index.duplicated(keep='first')]
     return ts
 
 

--- a/tests/test_fxmacrodata_fetch.py
+++ b/tests/test_fxmacrodata_fetch.py
@@ -1,0 +1,62 @@
+import unittest
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+
+from pinkfish.fetch import fetch_fxmacrodata_timeseries
+
+
+class TestFXMacroDataFetch(unittest.TestCase):
+
+    def test_fetch_fxmacrodata_timeseries(self):
+        class MockResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    'data': [
+                        {'date': '2026-01-02', 'val': 1.2},
+                        {'date': '2026-01-01', 'val': 1.1},
+                    ]
+                }
+
+        calls = {}
+
+        def mock_get(url, params, timeout):
+            calls['url'] = url
+            calls['params'] = params
+            calls['timeout'] = timeout
+            return MockResponse()
+
+        import pinkfish.fetch as fetch
+
+        original_get = fetch.requests.get
+        original_cache_dir = fetch._get_cache_dir
+        try:
+            fetch.requests.get = mock_get
+            with tempfile.TemporaryDirectory() as cache_dir:
+                fetch._get_cache_dir = lambda dir_name: Path(cache_dir)
+                ts = fetch_fxmacrodata_timeseries(
+                    'EUR/USD',
+                    '2026-01-01',
+                    '2026-01-02',
+                    api_key='test-key',
+                    api_root='https://example.test/api/v1',
+                    use_cache=False,
+                )
+        finally:
+            fetch.requests.get = original_get
+            fetch._get_cache_dir = original_cache_dir
+
+        self.assertEqual(calls['url'], 'https://example.test/api/v1/forex/EUR/USD')
+        self.assertEqual(calls['params']['api_key'], 'test-key')
+        self.assertIsInstance(ts, pd.DataFrame)
+        self.assertEqual(list(ts['close']), [1.1, 1.2])
+        self.assertEqual(list(ts.columns),
+                         ['open', 'high', 'low', 'close', 'adj_close', 'volume'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `fetch_fxmacrodata_timeseries()` for daily FX reference rates from FXMacroData.
- Cache results through pinkfish's existing timeseries cache path and return lower-case OHLCV columns plus `adj_close`.
- Export the helper from the package root and add a mocked unit test.

## Validation
- `python -m pytest tests\\test_fxmacrodata_fetch.py`
- `python -m py_compile pinkfish\\fetch.py pinkfish\\__init__.py tests\\test_fxmacrodata_fetch.py`